### PR TITLE
feat: support custom headers in direct connection HTTP stream

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -89,6 +89,7 @@ const App = () => {
   const [bearerToken, setBearerToken] = useState<string>(() => {
     return localStorage.getItem("lastBearerToken") || "";
   });
+  const [customHeaders, setCustomHeaders] = useState<Record<string, string>>({});
   const [directConnection, setDirectConnection] = useState<boolean>(() => {
     return localStorage.getItem("lastDirectConnection") === "true" || false;
   });
@@ -134,6 +135,7 @@ const App = () => {
     sseUrl,
     env,
     bearerToken,
+    customHeaders,
     directConnection,
     proxyServerUrl: PROXY_SERVER_URL,
     onNotification: (notification) => {
@@ -459,6 +461,8 @@ const App = () => {
         setEnv={setEnv}
         bearerToken={bearerToken}
         setBearerToken={setBearerToken}
+        customHeaders={customHeaders}
+        setCustomHeaders={setCustomHeaders}
         directConnection={directConnection}
         setDirectConnection={setDirectConnection}
         onConnect={connectMcpServer}

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -41,6 +41,8 @@ interface SidebarProps {
   setEnv: (env: Record<string, string>) => void;
   bearerToken: string;
   setBearerToken: (token: string) => void;
+  customHeaders: Record<string, string>;
+  setCustomHeaders: (headers: Record<string, string>) => void;
   directConnection: boolean;
   setDirectConnection: (direct: boolean) => void;
   onConnect: () => void;
@@ -64,6 +66,8 @@ const Sidebar = ({
   setEnv,
   bearerToken,
   setBearerToken,
+  customHeaders,
+  setCustomHeaders,
   directConnection,
   setDirectConnection,
   onConnect,
@@ -75,7 +79,9 @@ const Sidebar = ({
   const [theme, setTheme] = useTheme();
   const [showEnvVars, setShowEnvVars] = useState(false);
   const [showBearerToken, setShowBearerToken] = useState(false);
+  const [showCustomHeaders, setShowCustomHeaders] = useState(false);
   const [shownEnvVars, setShownEnvVars] = useState<Set<string>>(new Set());
+  const [shownHeaderValues, setShownHeaderValues] = useState<Set<string>>(new Set());
 
   const handleTransportTypeChange = (type: "stdio" | "sse" | "streamableHttp") => {
     setTransportType(type);
@@ -203,6 +209,125 @@ const Sidebar = ({
                   </div>
                 )}
               </div>
+              {(transportType === "streamableHttp" && directConnection) && (
+                <div className="space-y-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => setShowCustomHeaders(!showCustomHeaders)}
+                    className="flex items-center w-full"
+                  >
+                    {showCustomHeaders ? (
+                      <ChevronDown className="w-4 h-4 mr-2" />
+                    ) : (
+                      <ChevronRight className="w-4 h-4 mr-2" />
+                    )}
+                    Custom Headers
+                  </Button>
+                  {showCustomHeaders && (
+                    <div className="space-y-2">
+                      {Object.entries(customHeaders).map(([key, value], idx) => (
+                        <div key={idx} className="space-y-2 pb-4">
+                          <div className="flex gap-2">
+                            <Input
+                              placeholder="Header Name"
+                              value={key}
+                              onChange={(e) => {
+                                const newKey = e.target.value;
+                                const newHeaders = Object.entries(customHeaders).reduce(
+                                  (acc, [k, v]) => {
+                                    if (k === key) {
+                                      acc[newKey] = value;
+                                    } else {
+                                      acc[k] = v;
+                                    }
+                                    return acc;
+                                  },
+                                  {} as Record<string, string>,
+                                );
+                                setCustomHeaders(newHeaders);
+                                setShownHeaderValues((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(key)) {
+                                    next.delete(key);
+                                    next.add(newKey);
+                                  }
+                                  return next;
+                                });
+                              }}
+                              className="font-mono"
+                            />
+                            <Button
+                              variant="destructive"
+                              size="icon"
+                              className="h-9 w-9 p-0 shrink-0"
+                              onClick={() => {
+                                const { [key]: _removed, ...rest } = customHeaders;
+                                setCustomHeaders(rest);
+                              }}
+                            >
+                              ×
+                            </Button>
+                          </div>
+                          <div className="flex gap-2">
+                            <Input
+                              type={shownHeaderValues.has(key) ? "text" : "password"}
+                              placeholder="Value"
+                              value={value}
+                              onChange={(e) => {
+                                const newHeaders = { ...customHeaders };
+                                newHeaders[key] = e.target.value;
+                                setCustomHeaders(newHeaders);
+                              }}
+                              className="font-mono"
+                            />
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-9 w-9 p-0 shrink-0"
+                              onClick={() => {
+                                setShownHeaderValues((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(key)) {
+                                    next.delete(key);
+                                  } else {
+                                    next.add(key);
+                                  }
+                                  return next;
+                                });
+                              }}
+                              aria-label={
+                                shownHeaderValues.has(key) ? "Hide value" : "Show value"
+                              }
+                              aria-pressed={shownHeaderValues.has(key)}
+                              title={
+                                shownHeaderValues.has(key) ? "Hide value" : "Show value"
+                              }
+                            >
+                              {shownHeaderValues.has(key) ? (
+                                <Eye className="h-4 w-4" aria-hidden="true" />
+                              ) : (
+                                <EyeOff className="h-4 w-4" aria-hidden="true" />
+                              )}
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                      <Button
+                        variant="outline"
+                        className="w-full mt-2"
+                        onClick={() => {
+                          const key = "";
+                          const newHeaders = { ...customHeaders };
+                          newHeaders[key] = "";
+                          setCustomHeaders(newHeaders);
+                        }}
+                      >
+                        Add Header
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              )}
             </>
           )}
           {transportType === "stdio" && (

--- a/client/src/lib/hooks/useConnection.ts
+++ b/client/src/lib/hooks/useConnection.ts
@@ -56,6 +56,7 @@ interface UseConnectionOptions {
   env: Record<string, string>;
   proxyServerUrl: string;
   bearerToken?: string;
+  customHeaders?: Record<string, string>;
   requestTimeout?: number;
   directConnection?: boolean;
   onNotification?: (notification: Notification) => void;
@@ -107,6 +108,7 @@ export function useConnection({
   env,
   proxyServerUrl,
   bearerToken,
+  customHeaders = {},
   requestTimeout = DEFAULT_REQUEST_TIMEOUT_MSEC,
   directConnection = false,
   onNotification,
@@ -296,7 +298,7 @@ export function useConnection({
           console.warn("CORS preflight test failed. Connection might still work, but be prepared for CORS errors.");
         }
         
-        const directHeaders: Record<string, string> = {};
+        const directHeaders: Record<string, string> = {...customHeaders};
         if (bearerToken) {
           directHeaders["Authorization"] = `Bearer ${bearerToken}`;
         }
@@ -312,6 +314,7 @@ export function useConnection({
             useCredentials: false 
           });
         } else if (transportType === "streamableHttp") {
+          console.log("Creating streamableHttp transport with headers:", directHeaders);
           clientTransport = new DirectStreamableHttpTransport(serverUrl, {
             headers: directHeaders,
             useCredentials: false 


### PR DESCRIPTION
## Motivation and Context  
This change adds support for sending custom headers when establishing a direct HTTP stream connection.  
It's necessary for use cases where authentication tokens or other metadata must be sent with the initial request.

## How Has This Been Tested?  
Tested locally in a real application using both static and dynamic header values.  
Verified that headers are correctly set and received on the server side.

## Breaking Changes  
No breaking changes. Existing connections without custom headers continue to work as before.

## Types of changes  
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Documentation update

## Checklist  
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)  
- [x] My code follows the repository's style guidelines  
- [x] New and existing tests pass locally  
- [x] I have added appropriate error handling  
- [x] I have added or updated documentation as needed

## Additional context  
This change introduces a new configuration option \`headers\` within the direct connection stream setup.